### PR TITLE
Prevents null values from creating errors

### DIFF
--- a/js/build-advanced-directory.js
+++ b/js/build-advanced-directory.js
@@ -209,7 +209,7 @@ AdvancedDirectory.prototype.alphaSortByAttr = function (data, attr) {
     return data;
   }
   return data.sort( function(a,b){
-    if (!a.hasOwnProperty(attr) || !b.hasOwnProperty(attr)) {
+    if (!a[attr] || !b[attr]) {
       return 0;
     }
 


### PR DESCRIPTION
...because

```js
// a[attr] = null
a.hasOwnProperty(attr) // would return true
```