### PR TITLE
new hook for getting data

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -6,7 +6,6 @@ Fliplet().then(function () {
     var uuid = $(this).data('directory-uuid');
     var config = Fliplet.Widget.getData(id);
     var pvKey = 'data-directory-source-' + uuid;
-    var getData;
 
     Fliplet.Hooks.run('flDirectoryBeforeGetData', {
       config: config,

--- a/js/build.js
+++ b/js/build.js
@@ -6,11 +6,26 @@ Fliplet().then(function () {
     var uuid = $(this).data('directory-uuid');
     var config = Fliplet.Widget.getData(id);
     var pvKey = 'data-directory-source-' + uuid;
-    if (config.source) {
+    var getData;
 
-      // Always start by attempting to use locally cached data
-      Fliplet.Storage.get(pvKey)
-        .then(function (cachedSource) {
+    Fliplet.Hooks.run('flDirectoryBeforeGetData', {
+      config: config,
+      container: container
+    }).then(function() {
+      if (config.getData) {
+        if (typeof config.getData !== 'function') {
+          throw new Error('getData is expected to be a function');
+        }
+
+        config.getData().then(function (rows) {
+          config.rows = rows;
+          dataDirectory[id] = new AdvancedDirectory(config, container);
+        }).catch(function (err) {
+          console.error('Could not initialise directory', err);
+        });
+      } else if (config.source) {
+        // Always start by attempting to use locally cached data
+        Fliplet.Storage.get(pvKey).then(function (cachedSource) {
           if (cachedSource) {
             config.rows = cachedSource.rows;
           } else {
@@ -22,12 +37,13 @@ Fliplet().then(function () {
             };
             Fliplet.Storage.set(pvKey, cachedSource);
           }
+
           dataDirectory[id] = new AdvancedDirectory(config, container);
 
           if (config.enable_live_data && Fliplet.Navigator.isOnline()) {
             var sourceUpdatedAt = cachedSource.updatedAt;
 
-            Fliplet.DataSources.connect(config.source, {offline: false})
+            Fliplet.DataSources.connect(config.source, { offline: false })
               .then(function (source) {
                 return source.find();
               })
@@ -47,6 +63,15 @@ Fliplet().then(function () {
               });
           }
         });
-    }
+      } else {
+        if (Fliplet.UI) {
+          Fliplet.UI.Toast('This directory is not properly configured.');
+        }
+
+        // Load empty directory
+        config.rows = [];
+        dataDirectory[id] = new AdvancedDirectory(config, container);
+      }
+    });
   });
 });


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-studio/issues/2740

--- 

Adds support for the `flDirectoryBeforeGetData` hook and `getData(<Function>)`.

```js
Fliplet.Hooks.on('flDirectoryBeforeGetData', function (data) {
  data.config.getData = function () {
    return Promise.resolve([{ Name: 'asd' }])
  };
})
```