### PR TITLE
Debounces search event tracking by 1 second

### DIFF
--- a/js/build-advanced-directory.js
+++ b/js/build-advanced-directory.js
@@ -1047,7 +1047,6 @@ AdvancedDirectory.prototype.renderSearchResult = function( options, callback ){
           action: 'search',
           label: options.value
         });
-        console.log('search', options.value);
       }, this.searchLogLimit);
 
       break;

--- a/js/build-advanced-directory.js
+++ b/js/build-advanced-directory.js
@@ -63,8 +63,11 @@ var AdvancedDirectory = function (config, container) {
   this.filterOverlay = null;
   this.entryOverlay = null;
   this.searchResultData = [];
+  this.liveSearchTimeout = null;
   this.liveSearchInterval = 200;
-  this.currentEntry;
+  this.searchLogTimeout = null;
+  this.searchLogLimit = 1000;
+  this.currentEntry = null;
 
   this.checkMobileMode();
 
@@ -951,6 +954,7 @@ AdvancedDirectory.prototype.renderLiveSearch = function( value ) {
     this.liveSearchTimeout = null;
   }
   this.liveSearchTimeout = setTimeout(function(){
+    _this.liveSearchTimeout = null;
     _this.renderSearchResult( {
       type: 'search',
       value: value
@@ -960,6 +964,7 @@ AdvancedDirectory.prototype.renderLiveSearch = function( value ) {
 };
 
 AdvancedDirectory.prototype.renderSearchResult = function( options, callback ){
+  var _this = this;
   options = options || {};
 
   if (!options.hasOwnProperty('userTriggered')) {
@@ -1027,10 +1032,23 @@ AdvancedDirectory.prototype.renderSearchResult = function( options, callback ){
     default:
       data.type = 'search';
       data.value = options.value;
-      data.result = this.search( options.value );
+      data.result = this.search(options.value);
 
-      // Analytics - Track Event
-      Fliplet.Analytics.trackEvent({ category: 'directory', action: 'search', title: options.type + ': ' + options.value });
+      if (this.searchLogTimeout) {
+        clearTimeout(this.searchLogTimeout);
+        this.searchLogTimeout = null;
+      }
+
+      this.searchLogTimeout = setTimeout(function () {
+        _this.searchLogTimeout = null;
+        // Analytics - Track Event
+        Fliplet.Analytics.trackEvent({
+          category: 'directory',
+          action: 'search',
+          label: options.value
+        });
+        console.log('search', options.value);
+      }, this.searchLogLimit);
 
       break;
   }


### PR DESCRIPTION
Deals with the following [reported issue](https://docs.google.com/spreadsheets/d/1ITLCZm9fg_A-LIYQDbJsNyTWqPFyF0_25F6-cIR9Z84/edit):

> directory/adv directory - text searches are logged after each letter leading to many search entries logged although the user hadn't finished typing e.g. 'ted' resulted in 3 search events logged